### PR TITLE
LCP 최적화: 가격 텍스트 영역 초기 공백 렌더링 방식으로 수정

### DIFF
--- a/src/components/chart/CoinDetail.tsx
+++ b/src/components/chart/CoinDetail.tsx
@@ -88,29 +88,21 @@ const CoinDetail = ({
         </div>
 
         <div className="text-right space-y-0.5 lg:space-y-1 shrink-0 flex items-center">
-          {isLoading ? (
-            <div className="flex flex-col gap-2 w-40 xs:w-80 bg-white/5 animate-pulse">
-              <div className="h-6 w-full bg-gray-500/30 rounded" />
-              <div className="h-4 w-2/3 bg-gray-500/20 rounded" />
-              <div className="h-3 w-3/4 bg-gray-500/10 rounded" />
+          <div className="flex flex-col gap-1">
+            <span
+              className="block text-lg md:text-xl lg:text-3xl font-semibold text-white truncate min-h-[1.5rem]"
+              aria-label="price"
+            >
+              {isLoading ? "\u00A0" : formattedPrice}
+            </span>
+            <div className={`text-xs lg:text-base ${rateColor}`}>
+              {(changeRate * 100).toFixed(2)}% ({change > 0 ? "+" : ""}
+              {formattedChange})
             </div>
-          ) : (
-            <div className="flex flex-col gap-1">
-              <span
-                className="block text-lg md:text-xl lg:text-3xl font-semibold text-white truncate min-h-[1.5rem]"
-                aria-label="price"
-              >
-                {isLoading ? "\u00A0" : formattedPrice}
-              </span>
-              <div className={`text-xs lg:text-base ${rateColor}`}>
-                {(changeRate * 100).toFixed(2)}% ({change > 0 ? "+" : ""}
-                {formattedChange})
-              </div>
-              <div className="text-[10px] lg:text-sm text-gray-400 truncate">
-                24H 거래대금: {formattedVolume}
-              </div>
+            <div className="text-[10px] lg:text-sm text-gray-400 truncate">
+              24H 거래대금: {formattedVolume}
             </div>
-          )}
+          </div>
 
           {isMobile && onToggleView && (
             <button


### PR DESCRIPTION
# 📄 Pull Request 템플릿

## ✅ PR 유형 (하나 이상 선택해주세요)

- [ ] 페이지 추가
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 버그 수정
- [ ] 스타일 추가/변경 (UI/디자인)

## 🔀 반영 브랜치

- `main` <- `refactor` 

## 🚀 작업 개요

- 성능 개선: LCP 최적화 및 bfcache 관련 구조 점검

## 🛠 작업 상세 내용

- CoinDetail의 가격 텍스트 영역에 초기 공백(\u00A0) 렌더링 추가 → LCP paint 지연 최소화
- WebSocket 사용으로 인해 bfcache는 브라우저 정책상 차단됨을 확인, 관련 최적화는 제외

## 📚 참고 자료

## 🔍 추가 정보

- bfcache(뒤로/앞으로 캐시)는 WebSocket 연결이 유지된 상태에서는 브라우저 정책상 사용 불가

## ✅ PR 체크리스트

- [x] ✅ 커밋 메시지 컨벤션을 따랐습니다.
- [x] 🔍 변경 사항에 대해 테스트를 완료했습니다.
- [x] 🧾 작업 상세 내용을 충분히 기술했습니다.
- [x] 🎨 코드 스타일과 품질을 확인했습니다.